### PR TITLE
dgol should stay under the root supervisor

### DIFF
--- a/src/dgol.erl
+++ b/src/dgol.erl
@@ -1,6 +1,7 @@
 -module(dgol).
 -behaviour(gen_server).
 
+-export([start_session/3]).
 -export([start_link/3]).
 -export([init/1, 
          handle_call/3, 
@@ -11,6 +12,18 @@
 
 -record(state, {size_x :: pos_integer(),
                 size_y :: pos_integer()}).
+
+-spec start_session(pos_integer(), pos_integer(), [cell:position(), ...]) ->
+                           supervisor:startchild_ret().
+start_session(Xdim, Ydim, InitialCells) ->
+    case whereis(dgol) of
+        undefined ->
+            supervisor:start_child(dgol_sup, 
+                                   {dgol, {dgol, start_link, [Xdim, Ydim, InitialCells]},
+                                           permanent, 2000, worker, [dgol]});
+        _ ->
+            {error, already_started}
+    end.
 
 -spec start_link(pos_integer(), pos_integer(), [cell:position(), ...]) -> 
                         {ok, pid()} | 

--- a/src/dgol_sup.erl
+++ b/src/dgol_sup.erl
@@ -2,8 +2,7 @@
 
 -behaviour(supervisor).
 
--export([start_link/0,
-         start_dgol_session/3]).
+-export([start_link/0]).
 -export([init/1]).
 
 -define(SERVER, ?MODULE).
@@ -11,22 +10,7 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
--spec start_dgol_session(pos_integer(), pos_integer(), [cell:position(), ...]) -> 
-                                supervisor:startchild_ret().
-start_dgol_session(Xdim, Ydim, InitialCells) ->
-    case whereis(dgol) of
-        undefined ->
-            supervisor:start_child(?SERVER, 
-                                   {dgol, {dgol, start_link, [Xdim, Ydim, InitialCells]},
-                                           permanent, 2000, worker, [dgol]});
-        _ ->
-            {error, already_started}
-    end.
-    
-
-
 %%% OTP callbacks
-
 init([]) ->
     RestartStrategy = {one_for_all, 0, 1},
     CellSup = {cell_sup, {cell_sup, start_link, []},


### PR DESCRIPTION
changelog:
- [x] dgol is now "linkable"
- [x] the root supervisor `dgol_sup` is now able to dynamically start a dgol session
